### PR TITLE
Center-align countdown numbers

### DIFF
--- a/copium-tracker.js
+++ b/copium-tracker.js
@@ -108,7 +108,7 @@
                   .map(
                       (k) => `
                 <div class="flex flex-col p-2 rounded-box text-neutral-content border">
-                  <span class="countdown font-mono text-5xl" id="${cfg.countdownIds[k]}">
+                  <span class="countdown justify-center font-mono text-5xl" id="${cfg.countdownIds[k]}">
                     <span style="--value:0"></span>
                   </span>
                   <span class="text-xs comic-font">${k}</span>
@@ -146,7 +146,7 @@
                         .map(
                             (k) => `
                       <div class="flex flex-col p-2 rounded-box text-neutral-content border border-blue-400/30">
-                        <span class="countdown font-mono text-2xl" id="${k}-${event.id}">
+                        <span class="countdown justify-center font-mono text-2xl" id="${k}-${event.id}">
                           <span style="--value:0"></span>
                         </span>
                         <span class="text-xs comic-font">${k}</span>


### PR DESCRIPTION
They look nicer this way.

Before:
<img width="300" height="83" alt="image" src="https://github.com/user-attachments/assets/81d7b0b5-15bf-4ffd-9a79-28fbc0fd03a3" />

After:
<img width="300" height="83" alt="image" src="https://github.com/user-attachments/assets/118922f9-3320-49e6-8086-3d4d632ee55b" />
